### PR TITLE
Improve content editor tab styles

### DIFF
--- a/css/mhvlug.css
+++ b/css/mhvlug.css
@@ -407,6 +407,11 @@ ul.primary a {
 }
 
 /* Content editor tabs */
+#section-content .tabs ul.secondary li:hover,
+#section-content .tabs ul.primary li:hover {
+    background-color: #F7E7DF;
+}
+
 #section-content .tabs ul.secondary li,
 #section-content .tabs ul.primary li {
     font-size: 1.2em;

--- a/css/mhvlug.css
+++ b/css/mhvlug.css
@@ -406,6 +406,12 @@ ul.primary a {
     background-color: white;
 }
 
+/* Content editor tabs */
+#section-content .tabs ul.secondary li,
+#section-content .tabs ul.primary li {
+    font-size: 1.2em;
+}
+
 /*** BOX AROUND MEETING ***/
 .sidebar .block,
 #front-right .content .view-upcoming-events,


### PR DESCRIPTION
First, definitions: for lack of a more idiomatic term, the "content editor tabs" refer to the tabs you see when you can edit a given block of content.

These two commit solve two problems. The editor tabs were squinty-sized, so I made them slightly bigger. This doesn't appear to break any layout I have tested so far. Also, hover states of the tabs was inconsistant with the main nav. The rule appears to be: if you are hovering above the tabs, make the background lighter, but not as light as the active tab.
