### PR TITLE
Improve content editor tab styles for 7.x-1.x

### DIFF
--- a/css/mhvlug.css
+++ b/css/mhvlug.css
@@ -407,6 +407,11 @@ ul.primary a {
 }
 
 /* Content editor tabs */
+#section-content .tabs ul.secondary li:hover,
+#section-content .tabs ul.primary li:hover {
+    background-color: #F7E7DF;
+}
+
 #section-content .tabs ul.secondary li,
 #section-content .tabs ul.primary li {
     font-size: 1.2em;

--- a/css/mhvlug.css
+++ b/css/mhvlug.css
@@ -406,6 +406,12 @@ ul.primary a {
     background-color: white;
 }
 
+/* Content editor tabs */
+#section-content .tabs ul.secondary li,
+#section-content .tabs ul.primary li {
+    font-size: 1.2em;
+}
+
 /*** BOX AROUND MEETING ***/
 .sidebar .block,
 #front-right .content .view-upcoming-events,


### PR DESCRIPTION
I've merged the changes originally discussed in https://github.com/sdague/mhvlug-theme/pull/3 for the 7.x-1.x branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hvopen/mhvlug-theme/4)
<!-- Reviewable:end -->
